### PR TITLE
feat!: drop support for node 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dist"
   ],
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build": "tsup",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the minimum required Node.js version to 20.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->